### PR TITLE
Fix: VK_KHR_portability_enumeration extension

### DIFF
--- a/src/render/vulkan/vk_base.cpp
+++ b/src/render/vulkan/vk_base.cpp
@@ -200,6 +200,11 @@ void vk_base::create_instance(const char *appName) {
                                            extensionProps.data());
 
     for (const auto &v : extensionProps) {
+      if (std::string(v.extensionName) ==
+          std::string(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        Logger::info("VK_KHR_portability_enumeration found");
+      }
+
       extensions.push_back(v.extensionName);
     }
   }
@@ -250,7 +255,6 @@ void vk_base::create_device() {
 
   std::vector<const char *> extensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
 #ifdef __APPLE__
-  extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
   extensions.push_back("VK_KHR_PORTABILITY_subset");
 #endif
   VkDeviceCreateInfo ci{};

--- a/src/render/vulkan/vk_base.cpp
+++ b/src/render/vulkan/vk_base.cpp
@@ -200,10 +200,12 @@ void vk_base::create_instance(const char *appName) {
                                            extensionProps.data());
 
     for (const auto &v : extensionProps) {
+#ifdef __APPLE__
       if (std::string(v.extensionName) ==
           std::string(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
         Logger::info("VK_KHR_portability_enumeration found");
       }
+#endif
 
       extensions.push_back(v.extensionName);
     }


### PR DESCRIPTION
`VK_KHR_portability_enumeration` is "instance" extension...
https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_portability_enumeration.html

(`VK_KHR_portability_subset` is device extension.
https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_portability_subset.html)