### PR TITLE
Fix: extension VK_KHR_PORTABILITY_subset off on macOS

### DIFF
--- a/src/render/vulkan/vk_base.cpp
+++ b/src/render/vulkan/vk_base.cpp
@@ -256,9 +256,6 @@ void vk_base::create_device() {
   devQueueCI.pQueuePriorities = &defaultQueuePriority;
 
   std::vector<const char *> extensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
-#ifdef __APPLE__
-  extensions.push_back("VK_KHR_PORTABILITY_subset");
-#endif
   VkDeviceCreateInfo ci{};
   ci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   ci.pQueueCreateInfos = &devQueueCI;


### PR DESCRIPTION
fixing #14 at last.